### PR TITLE
Better CORS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,16 +363,31 @@ const rules = [
 
 Adds cross origin request headers for a path. The cors handler can optionally take an array of allowed origins to enable cors for.
 
-An example of the configuration for cors handler:
+This is the default configuration for the cors handler
 
 ```
 config = [{
     handlerName: 'cors',
     options: {
-        allowedOrigins: ['http://domain.com'],
+        allowedOrigins = ['*'],
+        allowedMethods = ['GET', 'PUT', 'POST', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
+        allowCredentials = true,
+        allowedHeaders = ['Content-Type'],
+        allowedExposeHeaders = ['WWW-Authenticate', 'Server-Authorization'],
+        maxAge = 600,
+        optionsSuccessStatus = 204,
+        terminatePreflight = false
     }
 }];
 ```
+- `allowedOrigins` - Controls [`Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin). Array of allowed Origin domains, or a single item `['*']` if any Origin is allowed.
+- `allowedMethods` - Controls [`Access-Control-Allow-Methods` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods). Array of allowed methods. `['*']` is a valid value.
+- `allowCredentials` - Controls [`Access-Control-Allow-Credentials` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials). Boolean value.
+- `allowedHeaders` - Controls [`Access-Control-Allow-Headers` header]. Array of allowed request headers. `['*']` is a valid value.
+- `allowedExposeHeaders` - Controls [`Access-Control-Expose-Headers` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers). Array of allowed exposed headers. Set to `['*']` to allow exposing any headers. Set to `[]` to allow only the default 7 headers allowed by HTTP spec (see link).
+- `maxAge` - Constrols [`Access-Control-Max-Age` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age). Number of seconds that the CORS headers (`Access-Control-*`) should be cached by the client. Int value.
+- `terminatePreflight` - Set to true if you want `OPTIONS` requests to not be forwarded to origin.
+- `optionsSuccessStatus` - The HTTP status that should be returned in a preflight request. Only used if `terminatePreflight` is set to `true`
 
 ### Geo-decorator
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudworker-proxy",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/handlers/cors.js
+++ b/src/handlers/cors.js
@@ -1,17 +1,79 @@
-module.exports = function corsHandler({ allowedOrigins = ['*'] }) {
+module.exports = function corsHandler(
+  {
+    allowedOrigins = ['*'],
+    allowedMethods = ['GET','PUT','POST','PATCH','DELETE','HEAD','OPTIONS'],
+    allowCredentials = true,
+    allowedHeaders = ['Content-Type'],
+    allowedExposeHeaders = ['WWW-Authenticate', 'Server-Authorization'],
+    maxAge = '600',
+    optionsSuccessStatus = 204,
+    terminatePreflight = false
+  }) {
   return async (ctx, next) => {
-    const { origin } = ctx.request.headers;
+    const method = ctx.request.method
+    const origin = ctx.request.headers.origin
+    const requestHeaders = ctx.request.headers['access-control-request-headers']
 
-    if (origin) {
-      if (allowedOrigins[0] === '*' || allowedOrigins.indexOf(origin) !== -1) {
-        ctx.set('Access-Control-Allow-Credentials', 'true');
-        ctx.set('Access-Control-Allow-Origin', origin);
-        ctx.set('Access-Control-Allow-Methods', 'GET,PUT,POST,PATCH,DELETE,HEAD,OPTIONS');
-        ctx.set('Access-Control-Allow-Headers', 'Content-Type');
-        ctx.set('Access-Control-Expose-Headers', 'WWW-Authenticate,Server-Authorization');
+
+    if (method === 'OPTIONS') {
+      configureOrigin(ctx, origin, allowedOrigins);
+      configureCredentials(ctx, allowCredentials);
+      configureMethods(ctx, allowedMethods);
+      configureAllowedHeaders(ctx, requestHeaders, allowedHeaders);
+      configureMaxAge(ctx, maxAge);
+      configureExposedHeaders(ctx, allowedExposeHeaders);
+      if (terminatePreflight) {
+        ctx.status = optionsSuccessStatus;
+        ctx.set('Content-Length', '0');
+        ctx.body = '';
+        return;
       }
+    } else {
+      configureOrigin(ctx, origin, allowedOrigins);
+      configureCredentials(ctx, allowCredentials);
+      configureExposedHeaders(ctx, allowedExposeHeaders);
     }
-
     await next(ctx);
   };
 };
+
+
+function configureOrigin (ctx, origin, allowedOrigins) {
+  if (allowedOrigins === '*' || allowedOrigins.length && allowedOrigins[0] === '*') {
+    ctx.set('Access-Control-Allow-Origin', '*');
+  } else if (typeof allowedOrigins === 'string' && origin === allowedOrigins) {
+    ctx.set('Access-Control-Allow-Origin', origin);
+    ctx.set('Vary', 'Origin');
+  } else if (Array.isArray(allowedOrigins) && allowedOrigins.indexOf(origin) !== -1) {
+    ctx.set('Access-Control-Allow-Origin', origin);
+    ctx.set('Vary', 'Origin');
+  }
+}
+
+function configureCredentials (ctx, allowCredentials) {
+  ctx.set('Access-Control-Allow-Credentials', allowCredentials?'true':'false');
+}
+
+function configureMethods (ctx, allowedMethods) {
+  ctx.set('Access-Control-Allow-Methods', allowedMethods.join(','));
+}
+
+function configureAllowedHeaders (ctx, requestHeaders, allowedHeaders) {
+  if (allowedHeaders.length === 0 && requestHeaders) {
+    ctx.set('Access-Control-Allow-Headers', requestHeaders) //allowedHeaders wasn't specified, so reflect the request headers
+  } else if (allowedHeaders.length) {
+    ctx.set('Access-Control-Allow-Headers', allowedHeaders.join(','))
+  }
+}
+
+function configureMaxAge (ctx, maxAge) {
+  if (maxAge) {
+    ctx.set('Access-Control-Max-Age', ""+maxAge)
+  }
+}
+
+function configureExposedHeaders (ctx, allowedExposeHeaders) {
+  if (allowedExposeHeaders.length) {
+    ctx.set('Access-Control-Expose-Headers', allowedExposeHeaders.join(','));
+  }
+}

--- a/src/handlers/cors.js
+++ b/src/handlers/cors.js
@@ -5,7 +5,7 @@ module.exports = function corsHandler(
     allowCredentials = true,
     allowedHeaders = ['Content-Type'],
     allowedExposeHeaders = ['WWW-Authenticate', 'Server-Authorization'],
-    maxAge = '600',
+    maxAge = 600,
     optionsSuccessStatus = 204,
     terminatePreflight = false
   }) {
@@ -15,23 +15,20 @@ module.exports = function corsHandler(
     const requestHeaders = ctx.request.headers['access-control-request-headers']
 
 
+    configureOrigin(ctx, origin, allowedOrigins);
+    configureCredentials(ctx, allowCredentials);
+    configureExposedHeaders(ctx, allowedExposeHeaders);
+    //handle preflight requests
     if (method === 'OPTIONS') {
-      configureOrigin(ctx, origin, allowedOrigins);
-      configureCredentials(ctx, allowCredentials);
       configureMethods(ctx, allowedMethods);
       configureAllowedHeaders(ctx, requestHeaders, allowedHeaders);
       configureMaxAge(ctx, maxAge);
-      configureExposedHeaders(ctx, allowedExposeHeaders);
       if (terminatePreflight) {
         ctx.status = optionsSuccessStatus;
         ctx.set('Content-Length', '0');
         ctx.body = '';
         return;
       }
-    } else {
-      configureOrigin(ctx, origin, allowedOrigins);
-      configureCredentials(ctx, allowCredentials);
-      configureExposedHeaders(ctx, allowedExposeHeaders);
     }
     await next(ctx);
   };
@@ -39,19 +36,18 @@ module.exports = function corsHandler(
 
 
 function configureOrigin (ctx, origin, allowedOrigins) {
-  if (allowedOrigins === '*' || allowedOrigins.length && allowedOrigins[0] === '*') {
-    ctx.set('Access-Control-Allow-Origin', '*');
-  } else if (typeof allowedOrigins === 'string' && origin === allowedOrigins) {
-    ctx.set('Access-Control-Allow-Origin', origin);
-    ctx.set('Vary', 'Origin');
-  } else if (Array.isArray(allowedOrigins) && allowedOrigins.indexOf(origin) !== -1) {
-    ctx.set('Access-Control-Allow-Origin', origin);
-    ctx.set('Vary', 'Origin');
+  if (Array.isArray(allowedOrigins)) {
+    if (allowedOrigins[0] === '*') {
+      ctx.set('Access-Control-Allow-Origin', '*');
+    } else if (allowedOrigins.indexOf(origin) !== -1) {
+      ctx.set('Access-Control-Allow-Origin', origin);
+      ctx.set('Vary', 'Origin');
+    }
   }
 }
 
 function configureCredentials (ctx, allowCredentials) {
-  ctx.set('Access-Control-Allow-Credentials', allowCredentials?'true':'false');
+  ctx.set('Access-Control-Allow-Credentials', allowCredentials);
 }
 
 function configureMethods (ctx, allowedMethods) {
@@ -68,7 +64,7 @@ function configureAllowedHeaders (ctx, requestHeaders, allowedHeaders) {
 
 function configureMaxAge (ctx, maxAge) {
   if (maxAge) {
-    ctx.set('Access-Control-Max-Age', ""+maxAge)
+    ctx.set('Access-Control-Max-Age', maxAge)
   }
 }
 

--- a/src/handlers/cors.js
+++ b/src/handlers/cors.js
@@ -1,24 +1,22 @@
-module.exports = function corsHandler(
-  {
-    allowedOrigins = ['*'],
-    allowedMethods = ['GET','PUT','POST','PATCH','DELETE','HEAD','OPTIONS'],
-    allowCredentials = true,
-    allowedHeaders = ['Content-Type'],
-    allowedExposeHeaders = ['WWW-Authenticate', 'Server-Authorization'],
-    maxAge = 600,
-    optionsSuccessStatus = 204,
-    terminatePreflight = false
-  }) {
+module.exports = function corsHandler({
+  allowedOrigins = ['*'],
+  allowedMethods = ['GET', 'PUT', 'POST', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
+  allowCredentials = true,
+  allowedHeaders = ['Content-Type'],
+  allowedExposeHeaders = ['WWW-Authenticate', 'Server-Authorization'],
+  maxAge = 600,
+  optionsSuccessStatus = 204,
+  terminatePreflight = false,
+}) {
   return async (ctx, next) => {
-    const method = ctx.request.method
-    const origin = ctx.request.headers.origin
-    const requestHeaders = ctx.request.headers['access-control-request-headers']
-
+    const { method } = ctx.request;
+    const { origin } = ctx.request.headers;
+    const requestHeaders = ctx.request.headers['access-control-request-headers'];
 
     configureOrigin(ctx, origin, allowedOrigins);
     configureCredentials(ctx, allowCredentials);
     configureExposedHeaders(ctx, allowedExposeHeaders);
-    //handle preflight requests
+    // handle preflight requests
     if (method === 'OPTIONS') {
       configureMethods(ctx, allowedMethods);
       configureAllowedHeaders(ctx, requestHeaders, allowedHeaders);
@@ -34,8 +32,7 @@ module.exports = function corsHandler(
   };
 };
 
-
-function configureOrigin (ctx, origin, allowedOrigins) {
+function configureOrigin(ctx, origin, allowedOrigins) {
   if (Array.isArray(allowedOrigins)) {
     if (allowedOrigins[0] === '*') {
       ctx.set('Access-Control-Allow-Origin', '*');
@@ -46,29 +43,31 @@ function configureOrigin (ctx, origin, allowedOrigins) {
   }
 }
 
-function configureCredentials (ctx, allowCredentials) {
-  ctx.set('Access-Control-Allow-Credentials', allowCredentials);
+function configureCredentials(ctx, allowCredentials) {
+  if (allowCredentials) {
+    ctx.set('Access-Control-Allow-Credentials', allowCredentials);
+  }
 }
 
-function configureMethods (ctx, allowedMethods) {
+function configureMethods(ctx, allowedMethods) {
   ctx.set('Access-Control-Allow-Methods', allowedMethods.join(','));
 }
 
-function configureAllowedHeaders (ctx, requestHeaders, allowedHeaders) {
+function configureAllowedHeaders(ctx, requestHeaders, allowedHeaders) {
   if (allowedHeaders.length === 0 && requestHeaders) {
-    ctx.set('Access-Control-Allow-Headers', requestHeaders) //allowedHeaders wasn't specified, so reflect the request headers
+    ctx.set('Access-Control-Allow-Headers', requestHeaders); // allowedHeaders wasn't specified, so reflect the request headers
   } else if (allowedHeaders.length) {
-    ctx.set('Access-Control-Allow-Headers', allowedHeaders.join(','))
+    ctx.set('Access-Control-Allow-Headers', allowedHeaders.join(','));
   }
 }
 
-function configureMaxAge (ctx, maxAge) {
+function configureMaxAge(ctx, maxAge) {
   if (maxAge) {
-    ctx.set('Access-Control-Max-Age', maxAge)
+    ctx.set('Access-Control-Max-Age', maxAge);
   }
 }
 
-function configureExposedHeaders (ctx, allowedExposeHeaders) {
+function configureExposedHeaders(ctx, allowedExposeHeaders) {
   if (allowedExposeHeaders.length) {
     ctx.set('Access-Control-Expose-Headers', allowedExposeHeaders.join(','));
   }

--- a/test/handlers/cors.test.js
+++ b/test/handlers/cors.test.js
@@ -3,7 +3,7 @@ const CorsHandler = require('../../src/handlers/cors');
 const helpers = require('../helpers');
 
 describe('corsHandler', () => {
-  it('should not add any cors header if the origin is not in the allowed headers list', async () => {
+  it('should not return Access-Control-Allow-Origin if the origin is not in the allowed headers list', async () => {
     const corsHandler = CorsHandler({
       allowedOrigins: [],
     });
@@ -12,28 +12,165 @@ describe('corsHandler', () => {
 
     await corsHandler(ctx, helpers.getNext());
 
-    expect(ctx.response.headers.size).to.equal(0);
+    expect(ctx.response.headers.get('Access-Control-Allow-Origin')).to.equal(undefined);
   });
-
-  it('should add cors header if the origin is in the allowed headers list', async () => {
+  it('should return Access-Control-Allow-Origin "*", if allowedOrigin = ["*"]', async () => {
     const corsHandler = CorsHandler({
-      allowedOrigins: ['http://localhost'],
+      allowedOrigins: ['*'],
     });
-
-    const ctx = helpers.getCtx();
-
+    const ctx = helpers.getCtx()
     await corsHandler(ctx, helpers.getNext());
-
-    expect(ctx.response.headers.size).to.not.equal(0);
+    expect(ctx.response.headers.get('Access-Control-Allow-Origin')).to.equal('*')
+  });
+  it('should return Access-Control-Allow-Origin, if Origin is in allowedOrigin array', async () => {
+    const corsHandler = CorsHandler({
+      allowedOrigins: ['somehost','localhost'],
+    });
+    const ctx = helpers.getCtx()
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Allow-Origin')).to.equal('localhost')
+  });
+  it('should return Access-Control-Expose-Headers that was configured', async () => {
+    const corsHandler = CorsHandler({
+      allowedExposeHeaders: ['Header1', 'Header2'],
+    });
+    const ctx = helpers.getCtx()
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Expose-Headers')).to.equal('Header1,Header2')
+  });
+  it('should return Access-Control-Allow-Credentials by default', async () => {
+    const corsHandler = CorsHandler({
+    });
+    const ctx = helpers.getCtx()
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Allow-Credentials')).to.equal(true)
+  });
+  it('should not return Access-Control-Allow-Credentials if it was set to false', async () => {
+    const corsHandler = CorsHandler({
+      allowCredentials: false
+    });
+    const ctx = helpers.getCtx()
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Allow-Credentials')).to.equal(undefined)
+  });
+  it('should not return Access-Control-Allow-Methods if method is not options', async () => {
+    const corsHandler = CorsHandler({
+    });
+    const ctx = helpers.getCtx()
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Allow-Methods')).to.equal(undefined)
+  });
+  it('should return Access-Control-Allow-Methods if method is OPTIONS', async () => {
+    const corsHandler = CorsHandler({
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS';
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Allow-Methods')).to.not.equal(undefined)
+  });
+  it('should return Access-Control-Allow-Methods with the methods that were configured', async () => {
+    const corsHandler = CorsHandler({
+      allowedMethods: ['POST', 'GET']
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS';
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Allow-Methods')).to.equal('POST,GET')
+  });
+  it('should not return Access-Control-Allow-Headers if method is not options', async () => {
+    const corsHandler = CorsHandler({
+    });
+    const ctx = helpers.getCtx()
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Allow-Headers')).to.equal(undefined)
+  });
+  it('should return Access-Control-Allow-Headers if method is OPTIONS', async () => {
+    const corsHandler = CorsHandler({
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS';
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Allow-Headers')).to.not.equal(undefined)
+  });
+  it('should return Access-Control-Allow-Headers with the request\'s requested headers if allowedHeaders is set to []' , async () => {
+    const corsHandler = CorsHandler({
+      allowedHeaders: []
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS'
+    ctx.request.headers['access-control-request-headers'] = 'Header1,Header2';
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Allow-Headers')).to.equal('Header1,Header2')
+  });
+  it('should return Access-Control-Allow-Headers with the allowedHeaders' , async () => {
+    const corsHandler = CorsHandler({
+      allowedHeaders: ['Header1','Header2']
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS'
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Allow-Headers')).to.equal('Header1,Header2')
+  });
+  it('should not return Access-Control-Max-Age if method is not OPTIONS' , async () => {
+    const corsHandler = CorsHandler({
+    });
+    const ctx = helpers.getCtx()
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Max-Age')).to.equal(undefined)
+  });
+  it('should return Access-Control-Max-Age if method is OPTIONS' , async () => {
+    const corsHandler = CorsHandler({
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS'
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Max-Age')).to.not.equal(undefined)
+  });
+  it('should return Access-Control-Max-Age with the configured maxAge' , async () => {
+    const corsHandler = CorsHandler({
+      maxAge: 1200
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS'
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Access-Control-Max-Age')).to.equal(1200)
+  });
+  it('should return no body if method is OPTIONS and terminatePreflight is set' , async () => {
+    const corsHandler = CorsHandler({
+      terminatePreflight: true
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS'
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.body).to.equal(undefined)
+  });
+  it('should return no Content-Length:0 header if method is OPTIONS and terminatePreflight is set' , async () => {
+    const corsHandler = CorsHandler({
+      terminatePreflight: true
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS'
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.response.headers.get('Content-Length')).to.equal('0')
+  });
+  it('should return response 204 if method is OPTIONS and terminatePreflight is set' , async () => {
+    const corsHandler = CorsHandler({
+      terminatePreflight: true
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS'
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.status).to.equal(204)
+  });
+  it('should return response defined in optionsSuccessStatus if method is OPTIONS and terminatePreflight is set' , async () => {
+    const corsHandler = CorsHandler({
+      terminatePreflight: true,
+      optionsSuccessStatus: 200
+    });
+    const ctx = helpers.getCtx()
+    ctx.request.method = 'OPTIONS'
+    await corsHandler(ctx, helpers.getNext());
+    expect(ctx.status).to.equal(200)
   });
 
-  it('should add cors header if the allowed headers list is not specified', async () => {
-    const corsHandler = CorsHandler({});
-
-    const ctx = helpers.getCtx();
-
-    await corsHandler(ctx, helpers.getNext());
-
-    expect(ctx.response.headers.size).to.not.equal(0);
-  });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -37,7 +37,7 @@ class Context {
 function getCtx() {
   const ctx = new Context();
   ctx.request.method = 'GET';
-  ctx.request.headers.origin = 'http://localhost';
+  ctx.request.headers.origin = 'localhost';
   ctx.request.hostname = 'example.com';
   ctx.request.host = 'example.com';
   ctx.request.protocol = 'http';


### PR DESCRIPTION
1. CORS preflight request is not identified by `Origin` header that can be sent in different non CORS events too. It is identified by `OPTIONS` method and `Access-Control-Request-Method` header
2. Allow more fine grained control over CORS `Access-Control-*` headers using options.
3. Allow handling OPTIONS request in this plugin and immediately return without calling next handlers (i.e. without calling a backend service)

If you like these changes I can also update the docs.