### PR TITLE
Oauth2 header fix

### DIFF
--- a/examples/handler.js
+++ b/examples/handler.js
@@ -39,6 +39,18 @@ const rules = [
   },
   {
     handlerName: 'response',
+    protocol: 'http',
+    host: 'proxy.cloudproxy.io',
+    options: {
+      status: 302,
+      body: 'Redirect to https',
+      headers: {
+        location: 'https://proxy.cloudproxy.io',
+      },
+    },
+  },
+  {
+    handlerName: 'response',
     path: '/',
     options: {
       body: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudworker-proxy",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudworker-proxy",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "An api gateway for cloudflare workers",
   "main": "src/index.js",
   "scripts": {

--- a/src/handlers/logger.js
+++ b/src/handlers/logger.js
@@ -77,6 +77,7 @@ module.exports = function logger(options) {
           headers: _.get(ctx, 'request.headers'),
           method: _.get(ctx, 'request.method'),
           url: _.get(ctx, 'request.href'),
+          protocol: _.get(ctx, 'request.protocol'),
           body,
         },
         response: {

--- a/src/handlers/oauth2.js
+++ b/src/handlers/oauth2.js
@@ -1,5 +1,6 @@
 const cookie = require('cookie');
 const get = require('lodash.get');
+const set = require('lodash.set');
 const shortid = require('shortid');
 const KvStorage = require('../services/kv-storage');
 const jwtRefresh = require('./jwt-refresh');
@@ -7,6 +8,7 @@ const aes = require('../encryption/aes');
 
 const _ = {
   get,
+  set,
 };
 
 function getCookie({ cookieHeader = '', cookieName }) {

--- a/test/handlers/oauth2.test.js
+++ b/test/handlers/oauth2.test.js
@@ -127,5 +127,32 @@ describe('oauth2Handler', () => {
 
       expect(ctx.status).to.equal(200);
     });
+
+    it('should use the auth token from headers', async () => {
+      const oauth2Handler = Oauth2Handler({
+        oauth2AuthDomain: 'http://example.com',
+        oauth2ClientId: '1234',
+        oauth2Audience: 'test',
+        oauth2CallbackType: 'query',
+        kvNamespace: 'kvNamespace',
+        kvAccountId: 'kvAccountId',
+      });
+
+      const ctx = helpers.getCtx();
+      ctx.request.path = '/test';
+      ctx.request.href = 'http://example.com/test';
+      ctx.request.query = {
+        auth: 'should-not-be-used',
+      };
+      ctx.request.headers.authorization = 'Bearer header-token';
+
+      await oauth2Handler(ctx, (ctx) => {
+        ctx.status = 200;
+        ctx.body = 'Hello world';
+        expect(ctx.request.headers.authorization).to.equal('Bearer header-token');
+      });
+
+      expect(ctx.status).to.equal(200);
+    });
   });
 });


### PR DESCRIPTION
The oauth2 handler should use the Authorization header when it's available. A require for lodash was missing that caused it to crash.. 