### PR TITLE
Started looking at api-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ config = [  {
 }];
 ```
 
+### Api Key
+
+The api key handler resolves api key passed in headers, querystring or cookie.
+
+The api keys are stored in KV-Storage.
+
+A valid api-key can be used for:
+
+- Add the user data to the context state
+
 ### JWT
 
 The jwt handler validates any bearer tokens passed in the authencation headers.

--- a/src/handlers/api-keys.js
+++ b/src/handlers/api-keys.js
@@ -1,0 +1,62 @@
+const get = require('lodash.get');
+
+const KvStorage = require('../services/kv-storage');
+
+const _ = {
+  get,
+};
+
+function apiKeys({
+  createPath = '/api-keys',
+  kvAccountId,
+  kvNamespace,
+  kvAuthEmail,
+  kvAuthKey,
+  //   kvKeySeparator = '|',
+  //   kvPrefix = 'api-keys',
+  //   appKeyPrefix = 'APIKEY',
+  //   appKeyHashSecret = 'ReplaceThisStringWithValueSecret',
+}) {
+  const kvStorage = new KvStorage({
+    accountId: kvAccountId,
+    namespace: kvNamespace,
+    authEmail: kvAuthEmail,
+    authKey: kvAuthKey,
+  });
+
+  async function handleKeys(ctx) {
+    const userId = _.get(ctx, 'state.user.id');
+    if (!userId) {
+      ctx.status = 403;
+      ctx.body = 'Forbidden';
+    }
+  }
+
+  async function handleValidateKey(ctx, next) {
+    const apiKey = _.get(ctx, 'request.headers.x-api-key');
+    if (!apiKey) {
+      return next(ctx);
+    }
+
+    const data = await kvStorage.get(apiKey);
+    if (!data) {
+      ctx.status = 403;
+      ctx.body = 'Invalid api key';
+      return ctx;
+    }
+
+    ctx.state.user = JSON.parse(data);
+    return next(ctx);
+  }
+
+  return async function apiKeysHandler(ctx, next) {
+    switch (ctx.request.path) {
+      case createPath:
+        return handleKeys(ctx, next);
+      default:
+        return handleValidateKey(ctx, next);
+    }
+  };
+}
+
+module.exports = apiKeys;

--- a/test/handlers/api-keys.test.js
+++ b/test/handlers/api-keys.test.js
@@ -1,0 +1,71 @@
+const { expect } = require('chai');
+const apiKeysFactory = require('../../src/handlers/api-keys');
+const helpers = require('../helpers');
+const fetchMock = require('fetch-mock');
+
+function mockCall(key, returns = 'OK') {
+  fetchMock.mock(
+    `https://api.cloudflare.com/client/v4/accounts/accountId/storage/kv/namespaces/namespace/values/${key}`,
+    returns,
+  );
+}
+
+const kvConfig = {
+  kvAccountId: 'accountId',
+  kvNamespace: 'namespace',
+  kvAuthEmail: 'authEmail',
+  kvAuthKey: 'authKey',
+};
+
+describe('apiKeys', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  describe('validate', () => {
+    it('should write the value of the api key to the state of the context', async () => {
+      const handler = apiKeysFactory({
+        ...kvConfig,
+      });
+
+      mockCall('asdf', { value: 'value' });
+
+      const ctx = helpers.getCtx();
+      ctx.request.headers['x-api-key'] = 'asdf';
+
+      await handler(ctx, helpers.getNext());
+
+      expect(ctx.state.user.value).to.equal('value');
+    });
+
+    it('should return a 403 for request with an invalid api-key', async () => {
+      const handler = apiKeysFactory({
+        ...kvConfig,
+      });
+
+      const ctx = helpers.getCtx();
+      ctx.request.headers['x-api-key'] = 'asdf';
+      mockCall('asdf', 404);
+
+      await handler(ctx, helpers.getNext());
+
+      expect(ctx.status).to.equal(403);
+    });
+  });
+
+  describe('create', () => {
+    it('should return a 403 for request without a user', async () => {
+      const handler = apiKeysFactory({
+        ...kvConfig,
+      });
+
+      const ctx = helpers.getCtx();
+      ctx.request.path = '/api-keys';
+      ctx.request.method = 'POST';
+
+      await handler(ctx, helpers.getNext());
+
+      expect(ctx.status).to.equal(403);
+    });
+  });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,3 @@
-const stream = require('stream');
-
 class Context {
   constructor() {
     this.request = {


### PR DESCRIPTION
This is work in progress. 

The idea is that you can use static api keys to limit access to other handlers and origins. 

From my perspective it's basically swapping a static api-token for another token that probably expires after a short time.

It seems that api-tokens typically are passed in headers (either as basic auth or as a custom api-header) and as querystrings.

On the output side I can imagine supporting jwt's with refresh-tokens, pre-signed url's, basic auth and maybe custom text-blobs that are added to some header. I'm not sure what the scope of this handler should be? Should it just add some auth info to the state and a separate handler can use this info or should it add all headers so that the request can be passed on to an origin or loadbalancer handler?

How should the auth-data/tokens be handled that are stored in kv-storage? I don't really like storing anything as clear text so I think it needs to be encrypted somehow. In a normal server perspective the passwords are hashed, but in this case it's rather the tokens stored that are sensitive. I think we could use a similar approach to the oauth2-handler where part of the api-key is used to encrypt the tokens.