### PR TITLE
Added signature handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,33 @@ config = [  {
 }];
 ```
 
+### Signature
+
+Validates a hmac signature that should be available as a sign querystring parameter at the end of the url. If this parameter is not available or incorrect the handler will return a 403 error back to the client.
+
+The signature handler creates a signature based on the path so that a signed url will be valid even if the host changes. So if the `https://example.com/foo?bar=test` is signed, only the `/foo?bar=test` is signed and the result would be something like: `https://example.com/foo?bar=test&sign=4LQn8AjrvX6NogZ8KDEumw5UClOmE906WmE6vQZdwZU`
+
+An example of the configuration for the signature handler:
+
+```
+config = [  {
+    handlerName: 'signature',
+    path: '/.*',
+    options: {
+      secret: 'shhhhh....'
+    },
+}];
+```
+
+The signature can be added in using the following snippet:
+
+```
+  const nodeSignature = nodeCrypto
+    .createHmac('SHA256', 'shhhhh....')
+    .update('path')
+    .digest('base64');
+```
+
 ### Split
 
 Splits the request in two separate requests. The duplicated request will not return any results to the client, but can for instance be used to sample the traffic on a live website or to get webhooks to post to multiple endpoints.

--- a/examples/handler.js
+++ b/examples/handler.js
@@ -195,6 +195,13 @@ const rules = [
     },
   },
   {
+    handlerName: 'signature',
+    path: '/ae5ac453-f76e-4f95-a9d9-ecd865844990/:file*',
+    options: {
+      secret: process.env.SIGNATURE_SECRET,
+    },
+  },
+  {
     handlerName: 'response',
     path: '/edge',
     options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudworker-proxy",
-  "version": "1.11.0",
+  "version": "1.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -967,9 +967,9 @@
       "dev": true
     },
     "fetch-mock": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.5.0.tgz",
-      "integrity": "sha512-x5t6+6owOr2x8WdloBpuKy7bRZ+JRjRJjjZSsEbBVNfUI8JzJfRw5TtdOOd+OyWXxqQtMjMLdRWh35ZLhRlv3g==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.7.0.tgz",
+      "integrity": "sha512-f7/qRIllBXrVyJ/AWutduAbCo/DuRkStMWweprfFjr+DJhK92aNNFfdVPNxvn4kime/XhGqZZKD/zT8u/ouNvw==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudworker-proxy",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "An api gateway for cloudflare workers",
   "main": "src/index.js",
   "scripts": {
@@ -42,7 +42,7 @@
     "eslint-config-prettier": "6.11.0",
     "eslint-plugin-import": "2.20.2",
     "eslint-plugin-prettier": "3.1.3",
-    "fetch-mock": "9.5.0",
+    "fetch-mock": "9.7.0",
     "mocha": "7.1.2",
     "node-cloudworker": "1.1.3",
     "node-fetch": "2.6.0",

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -12,6 +12,7 @@ const origin = require('./origin');
 const response = require('./response');
 const rateLimit = require('./rate-limit');
 const s3 = require('./s3');
+const signature = require('./signature');
 const split = require('./split');
 const transform = require('./transform');
 
@@ -30,6 +31,7 @@ module.exports = {
   rateLimit,
   response,
   s3,
+  signature,
   split,
   transform,
 };

--- a/src/handlers/signature.js
+++ b/src/handlers/signature.js
@@ -1,0 +1,54 @@
+let keyCache;
+
+function str2ab(str) {
+  const uintArray = new Uint8Array(
+    str.split('').map((char) => {
+      return char.charCodeAt(0);
+    }),
+  );
+  return uintArray;
+}
+
+async function getKey(secret) {
+  if (!keyCache) {
+    // eslint-disable-next-line no-undef
+    keyCache = await crypto.subtle.importKey(
+      'raw',
+      str2ab(secret),
+      { name: 'HMAC', hash: { name: 'SHA-256' } },
+      false,
+      ['sign', 'verify'],
+    );
+  }
+  return keyCache;
+}
+
+async function sign(path, secret) {
+  const key = await getKey(secret);
+
+  // eslint-disable-next-line no-undef
+  const sig = await crypto.subtle.sign({ name: 'HMAC' }, key, str2ab(path));
+  // eslint-disable-next-line no-undef
+  return btoa(String.fromCharCode.apply(null, new Uint8Array(sig)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+module.exports = function signatureHandler({ secret }) {
+  return async (ctx, next) => {
+    const pathWithQuery = (ctx.request.path + ctx.request.search).replace(
+      /([?|&]sign=[\w|-]+)/,
+      '',
+    );
+
+    const signature = await sign(pathWithQuery, secret);
+
+    if (signature !== ctx.query.sign) {
+      ctx.status = 403;
+      return;
+    }
+
+    await next(ctx);
+  };
+};

--- a/test/encryption/hmac.test.js
+++ b/test/encryption/hmac.test.js
@@ -1,0 +1,35 @@
+const nodeCrypto = require('crypto');
+const { expect } = require('chai');
+
+function str2ab(str) {
+  const uintArray = new Uint8Array(
+    str.split('').map((char) => {
+      return char.charCodeAt(0);
+    }),
+  );
+  return uintArray;
+}
+
+describe('hmac', () => {
+  it('should get the same signature in node as in js', async () => {
+    // Generate the SHA-256 hash from the secret string
+    let key = await crypto.subtle.importKey(
+      'raw',
+      str2ab('secret'),
+      { name: 'HMAC', hash: { name: 'SHA-256' } },
+      false,
+      ['sign', 'verify'],
+    );
+
+    // Sign the "str" with the key generated previously
+    let sig = await crypto.subtle.sign({ name: 'HMAC' }, key, str2ab('message'));
+    const jsSignature = btoa(String.fromCharCode.apply(null, new Uint8Array(sig)));
+
+    const nodeSignature = nodeCrypto
+      .createHmac('SHA256', 'secret')
+      .update('message')
+      .digest('base64');
+
+    expect(nodeSignature).to.equal(jsSignature);
+  });
+});


### PR DESCRIPTION
Fixes #17 

Adds a new handler for validation of hmac signature. This can for instance be used in combination with the s3 handler to use custom signatures for s3 that are a bit more simple to handle than the v4 signatures...