### PR TITLE
Add support for query params on s3 requests and body to be passed through

### DIFF
--- a/src/handlers/s3.ts
+++ b/src/handlers/s3.ts
@@ -74,7 +74,7 @@ export default function s3HandlerFactory({
       headers.range = ctx.request.headers.range;
     }
 
-    const response = await aws.fetch(url, {
+    const response = await aws.fetch(url + (ctx.request.search || ''), {
       method: ctx.method || ctx.request.method,
       headers,
     });

--- a/src/handlers/s3.ts
+++ b/src/handlers/s3.ts
@@ -68,15 +68,12 @@ export default function s3HandlerFactory({
       ? utils.resolveParams(`${resolvedEndpoint}/{file}`, ctx.params)
       : resolvedEndpoint; // Bucket operations
 
-    const headers: Record<string, string> = {};
-
-    if (ctx.request.headers.range) {
-      headers.range = ctx.request.headers.range;
-    }
+    const headers = ctx.request.headers || {};
 
     const response = await aws.fetch(url + (ctx.request.search || ''), {
       method: ctx.method || ctx.request.method,
       headers,
+      ...(ctx.request.body && { body: ctx.request.body }),
     });
 
     ctx.status = response.status;

--- a/src/handlers/s3.ts
+++ b/src/handlers/s3.ts
@@ -68,7 +68,9 @@ export default function s3HandlerFactory({
       ? utils.resolveParams(`${resolvedEndpoint}/{file}`, ctx.params)
       : resolvedEndpoint; // Bucket operations
 
-    const headers = ctx.request.headers || {};
+    const headers = {
+      ...(ctx.request?.headers?.range && { range: ctx.request.headers.range }),
+    };
 
     const response = await aws.fetch(url + (ctx.request.search || ''), {
       method: ctx.method || ctx.request.method,

--- a/test/handlers/s3.test.ts
+++ b/test/handlers/s3.test.ts
@@ -81,4 +81,28 @@ describe('s3', () => {
     await s3(ctx);
     expect(ctx.status).to.equal(200);
   });
+
+
+
+  it('List bucket forwards query params', async () => {
+    fetchMock.mock(`http://localhost:9000/myBucket?prefix=foo&list-type=2`, {
+      status: 200,
+    });
+
+    const s3 = s3Factory({
+      endpoint: 'http://localhost:9000',
+      forcePathStyle: true,
+      bucket: 'myBucket',
+      accessKeyId: 'DERP',
+      secretAccessKey: 'DERP',
+      enableBucketOperations: true,
+    });
+
+    const ctx = helpers.getCtx();
+    ctx.request.search = '?prefix=foo&list-type=2';
+    ctx.params = {};
+    await s3(ctx);
+
+    expect(ctx.status).to.equal(200);
+  });
 });

--- a/test/handlers/s3.test.ts
+++ b/test/handlers/s3.test.ts
@@ -82,7 +82,7 @@ describe('s3', () => {
     expect(ctx.status).to.equal(200);
   });
 
-  it('Request headers are forwarded', async () => {
+  it('Range headers are forwarded', async () => {
     fetchMock.mock(`http://localhost:9000/myBucket`, (req) => {
       return {
         status: 200,
@@ -99,10 +99,10 @@ describe('s3', () => {
 
     const ctx = helpers.getCtx();
     ctx.params = {};
-    ctx.request.headers['If-None-Match'] = 'blah';
+    ctx.request.headers['range'] = 'blah';
     await s3(ctx);
     expect(ctx.status).to.equal(200);
-    expect(fetchMock.lastOptions().headers['if-none-match']).to.equal('blah');
+    expect(fetchMock.lastOptions().headers['range']).to.equal('blah');
   });
 
   it('Request body is forwarded', async () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,7 +2,7 @@ class Context {
   request: {
     method: string;
     path: string;
-    query: {};
+    search?: string;
     hostname: string;
     host: string;
     protocol: string;
@@ -23,7 +23,7 @@ class Context {
       host: 'example.com',
       hostname: 'example.com',
       protocol: 'http',
-      query: {},
+      search: '',
       headers: {},
     };
     this.event = {};
@@ -34,9 +34,6 @@ class Context {
     };
     this.body = undefined;
     this.status = 404;
-
-    // Shortcuts directly on the context
-    this.query = this.request.query;
   }
 
   set(key: string, value: string) {


### PR DESCRIPTION
Current S3 handler ends up stripping query/body/header parameters which are useful for various s3 API functions.
